### PR TITLE
Add params when calling dom and remove unused allControlledVariables set

### DIFF
--- a/core/dom.py
+++ b/core/dom.py
@@ -14,7 +14,6 @@ def dom(response, params):
     for script in scripts:
         script = script.split('\n')
         num = 1
-        allControlledVariables = set()
         try:
             for newLine in script:
                 line = newLine

--- a/core/photon.py
+++ b/core/photon.py
@@ -40,7 +40,7 @@ def photon(seedUrl, headers, level, threadCount, delay, timeout, skipDOM):
         response = requester(url, params, headers, True, delay, timeout).text
         retireJs(url, response)
         if not skipDOM:
-            highlighted = dom(response)
+            highlighted = dom(response, params.keys() if params else [])
             clean_highlighted = ''.join([re.sub(r'^\d+\s+', '', line) for line in highlighted])
             if highlighted and clean_highlighted not in checkedDOMs:
                 checkedDOMs.append(clean_highlighted)


### PR DESCRIPTION
#### What does it implement/fix? Explain your changes.
- I tested the --crawl command on an endpoint where I know XSS exists
- I have also verified XSS exists via original XSS repo
- Using XSS-Reborn it does not detect XSS
- The newly added params parameter for the dom function was not added when the function is called
- I added the params parameter to the call
- Also removed unused variable

#### Where has this been tested?
Python Version: 3.8.12
Operating System: macOS

#### Does this close any currently open issues? 
No

#### Does this add any new dependency?
No

#### Does this add any new command line switch/option?
<!-- If you have added an argument which doesn't require a value, please don't use a shorthand for it. -->
<!-- For example, if you to introduce an option to disable colors please use --no-colors instead of -c -->
No

#### Any other comments you would like to make?

#### Some Questions
- [ ] I have documented my code.
- [x] I have tested my build before submitting the pull request.
